### PR TITLE
Fixes to quick sort and promote row and tests

### DIFF
--- a/enclave/column_sort.cpp
+++ b/enclave/column_sort.cpp
@@ -201,6 +201,12 @@ int reassemble_column_tables(table_t** s_tables, table_t *table, row_t *row, int
 				return -1;
 			}
 
+            // r*s can be larger than the actual number of rows
+            // therefore ignore the fake rows added while assembling
+            if (row->header.fake) {
+                continue;
+            }
+
 			/* Add row to the st table */
 			ret = write_row_dbg(table, row, row_num);
 			if(ret) {

--- a/enclave/sort_helper.cpp
+++ b/enclave/sort_helper.cpp
@@ -11,16 +11,16 @@
 
 #include <cerrno>
 
-void *get_element(table_t *tbl, int row_num, row_t *row_buf, int column)
+void *get_element(table_t *tbl, int row_num, row_t **row_buf, int column)
 {
 	int ret;
 	void *element;
 
 	if(tbl->pinned_blocks) {
 		data_block_t *b_i;
-		get_pinned_row(tbl, row_num, &b_i, &row_buf);
+		get_pinned_row(tbl, row_num, &b_i, row_buf);
 	} else {
-		ret = read_row(tbl, row_num, row_buf);
+		ret = read_row(tbl, row_num, *row_buf);
 
 		if(ret) {
 			ERR("failed to read row %d of table %s\n",
@@ -29,7 +29,7 @@ void *get_element(table_t *tbl, int row_num, row_t *row_buf, int column)
 		}
 	}
 
-	element = get_column(&tbl->sc, column, row_buf);
+	element = get_column(&tbl->sc, column, *row_buf);
 	return element;
 }
 
@@ -43,22 +43,25 @@ int verify_sorted_output(table_t *tbl, int start, int end, int column)
 		end = tbl->num_rows;
 	}
 	// alloc two rows
-	row_i = (row_t *)malloc(row_size(tbl));
-	if (!row_i) {
-		ERR("can't allocate memory for the row\n");
-		return -ENOMEM;
-	}
+	if (!tbl->pinned_blocks) {
+        row_i = (row_t *) malloc(row_size(tbl));
+        if (!row_i) {
+            ERR("can't allocate memory for the row\n");
+            return -ENOMEM;
+        }
 
-	row_j = (row_t *)malloc(row_size(tbl));
-	if (!row_j) {
-		ERR("can't allocate memory for the row\n");
-		return -ENOMEM;
-	}
+        row_j = (row_t *) malloc(row_size(tbl));
+        if (!row_j) {
+            ERR("can't allocate memory for the row\n");
+            return -ENOMEM;
+        }
+    }
+
 
 	// end is tbl->num_rows; we check until end - 2
 	for (i = start; i < end - 2; i++) {
-		void *element_i = get_element(tbl, i, row_i, column);
-		void *element_j = get_element(tbl, i + 1, row_j, column);
+		void *element_i = get_element(tbl, i, &row_i, column);
+		void *element_j = get_element(tbl, i + 1, &row_j, column);
 		if (!element_i || !element_j) {
 			ERR("%s, failed\n", __func__);
 			ret = 1;
@@ -68,12 +71,16 @@ int verify_sorted_output(table_t *tbl, int start, int end, int column)
 		if (tbl->sc.types[column] == INTEGER) {
 			ret |= (*((int*)element_i) > *((int *)element_j));
 		} else if (tbl->sc.types[column] == TINYTEXT) {
-			ret |= (strncmp((char*) element_i, (char*) element_j, MAX_ROW_SIZE) > 0);
+			int ans = 0;
+		    ans = (strncmp((char*) element_i, (char*) element_j, MAX_ROW_SIZE) > 0);
+			ret=ret + ans;
 		}
 	}
 
-	free(row_i);
-	free(row_j);
+	if (!tbl->pinned_blocks) {
+        free(row_i);
+        free(row_j);
+    }
 exit:
 	return ret;
 }

--- a/enclave/sort_helper.hpp
+++ b/enclave/sort_helper.hpp
@@ -1,7 +1,7 @@
 #ifndef _SORT_HELPER_H
 #define _SORT_HELPER_H
 
-void *get_element(table_t *tbl, int row_num, row_t *row_buf, int column);
+void *get_element(table_t *tbl, int row_num, row_t **row_buf, int column);
 int verify_sorted_output(table_t *tbl, int start, int end, int column);
 int exchange(table_t *tbl, int i, int j, row_t *row_i, row_t *row_j, int tid);
 


### PR DESCRIPTION
The patch fixes three major issues:

1) Pinning table when using quick sort was not working before 
2) quicksort partition function has a bug and was causing verify verify quick sort function to fail
3) promote_row was not working when 1st column and the column to be promoted were of different sizes
4) test sort merge and write was taking too long because of unnecessary  padding overhead. All the 
varchars were taken to be 255 chars long which is not true, this patch fixes the test to use the required number of chars for each varchar type.

test_merge_sort_write runs under 60 seconds with this patch